### PR TITLE
Sagea/add babel extension

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm test
       - run: npm run lint
+      - run: npm test
       - run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm test
       - run: npm run lint
+      - run: npm test
       - run: npm run build
       - uses: JS-DevTools/npm-publish@v1
         with:

--- a/babel.config.js
+++ b/babel.config.js
@@ -28,7 +28,9 @@ module.exports = api => {
       ['@babel/preset-env', babelPresetEnvOptions],
       '@babel/preset-typescript',
     ],
-    plugins: [],
+    plugins: [
+      ["babel-plugin-add-import-extension", { extension: "mjs" }]
+    ],
     ignore,
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -22,15 +22,15 @@ module.exports = api => {
         'src/**/__tests__/',
         'src/**/__snapshots__',
       ]
-
+  const plugins = isTest
+    ? []
+    : [['babel-plugin-add-import-extension', { extension: 'mjs' }]]
   return {
     presets: [
       ['@babel/preset-env', babelPresetEnvOptions],
       '@babel/preset-typescript',
     ],
-    plugins: [
-      ["babel-plugin-add-import-extension", { extension: "mjs" }]
-    ],
+    plugins,
     ignore,
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2326,6 +2326,15 @@
         }
       }
     },
+    "babel-plugin-add-import-extension": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.4.3.tgz",
+      "integrity": "sha512-NiKs80ucIlktWtQ6VGovyVprpgaDxqlo3fT2e2vIyF6k3+02YMmQt+QrBDOq/YImkK/pIXb/SKaO+FxKsfvNlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sage-generics",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/jest": "26.0.15",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",
+    "babel-plugin-add-import-extension": "1.4.3",
     "eslint": "7.13.0",
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sage-generics",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Collection of different event emitter emplimentations for my own use",
   "main": "es/index.mjs",
   "scripts": {

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,4 +1,4 @@
-import { CallbackFunction } from './CallbackFunction.js'
+import { CallbackFunction } from './CallbackFunction'
 
 export function Event<InvokeType>() {
   const callbacks = new Set<CallbackFunction<InvokeType>>()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Event } from './Event.js'
+export { Event } from './Event'


### PR DESCRIPTION
1. Modifies babel to add .mjs extension
2. Fixes issue in latest npmjs bundle where import extensions don't match bundled file extensions